### PR TITLE
Rename 'meta' to 'sys/system'

### DIFF
--- a/cmd_plan.go
+++ b/cmd_plan.go
@@ -1,12 +1,12 @@
 package migrate
 
 type CmdPlanInput struct {
-	Output       Printer
-	ConfigFile   string
-	DB           string
-	MigrationID  string
-	PrintSQL     bool
-	PrintMetaSQL bool
+	Output         Printer
+	ConfigFile     string
+	DB             string
+	MigrationID    string
+	PrintSQL       bool
+	PrintSystemSQL bool
 }
 
 func CmdPlan(input *CmdPlanInput) error {
@@ -21,9 +21,9 @@ func CmdPlan(input *CmdPlanInput) error {
 	}
 
 	steps.Print(PrintCtx{
-		Output:       input.Output,
-		PrintSQL:     input.PrintSQL || input.PrintMetaSQL,
-		PrintMetaSQL: input.PrintMetaSQL,
+		Output:         input.Output,
+		PrintSQL:       input.PrintSQL || input.PrintSystemSQL,
+		PrintSystemSQL: input.PrintSystemSQL,
 	})
 	return nil
 }

--- a/driver/mysql/migration_db.go
+++ b/driver/mysql/migration_db.go
@@ -53,8 +53,8 @@ CREATE TABLE IF NOT EXISTS %s (
 
 func (o *migrationDB) CreateTableIfNotExists() (migrate.Step, error) {
 	return &migrate.SQLExecStep{
-		Query:  fmt.Sprintf(createTableQuery, o.tableName),
-		IsMeta: true,
+		Query:    fmt.Sprintf(createTableQuery, o.tableName),
+		IsSystem: true,
 	}, nil
 }
 
@@ -63,16 +63,16 @@ const forwardMigrateQuery = `INSERT INTO %s (name, time) VALUES (?, ?) ON DUPLIC
 func (o *migrationDB) ForwardMigrate(migrationName string) (migrate.Step, error) {
 	now := time.Now().UTC()
 	return &migrate.SQLExecStep{
-		Query:  fmt.Sprintf(forwardMigrateQuery, o.tableName),
-		Args:   []interface{}{migrationName, now, now},
-		IsMeta: true,
+		Query:    fmt.Sprintf(forwardMigrateQuery, o.tableName),
+		Args:     []interface{}{migrationName, now, now},
+		IsSystem: true,
 	}, nil
 }
 
 func (o *migrationDB) BackwardMigrate(migrationName string) (migrate.Step, error) {
 	return &migrate.SQLExecStep{
-		Query:  fmt.Sprintf(`DELETE FROM %s WHERE name = ?;`, o.tableName),
-		Args:   []interface{}{migrationName},
-		IsMeta: true,
+		Query:    fmt.Sprintf(`DELETE FROM %s WHERE name = ?;`, o.tableName),
+		Args:     []interface{}{migrationName},
+		IsSystem: true,
 	}, nil
 }

--- a/driver/postgres/migration_db.go
+++ b/driver/postgres/migration_db.go
@@ -53,8 +53,8 @@ CREATE TABLE IF NOT EXISTS %s (
 
 func (o *migrationDB) CreateTableIfNotExists() (migrate.Step, error) {
 	return &migrate.SQLExecStep{
-		Query:  fmt.Sprintf(createTableQuery, o.tableName),
-		IsMeta: true,
+		Query:    fmt.Sprintf(createTableQuery, o.tableName),
+		IsSystem: true,
 	}, nil
 }
 
@@ -63,16 +63,16 @@ const forwardMigrateQuery = `INSERT INTO %s (name, time) VALUES ($1, $2) ON CONF
 func (o *migrationDB) ForwardMigrate(migrationName string) (migrate.Step, error) {
 	now := time.Now().UTC()
 	return &migrate.SQLExecStep{
-		Query:  fmt.Sprintf(forwardMigrateQuery, o.tableName),
-		Args:   []interface{}{migrationName, now},
-		IsMeta: true,
+		Query:    fmt.Sprintf(forwardMigrateQuery, o.tableName),
+		Args:     []interface{}{migrationName, now},
+		IsSystem: true,
 	}, nil
 }
 
 func (o *migrationDB) BackwardMigrate(migrationName string) (migrate.Step, error) {
 	return &migrate.SQLExecStep{
-		Query:  fmt.Sprintf(`DELETE FROM %s WHERE name=$1;`, o.tableName),
-		Args:   []interface{}{migrationName},
-		IsMeta: true,
+		Query:    fmt.Sprintf(`DELETE FROM %s WHERE name=$1;`, o.tableName),
+		Args:     []interface{}{migrationName},
+		IsSystem: true,
 	}, nil
 }

--- a/plan.go
+++ b/plan.go
@@ -80,14 +80,14 @@ func Plan(input *PlanInput) (Steps, error) {
 			return nil, fmt.Errorf("%q doesn't have a backward step", name)
 		}
 
-		updateMetaStep, err := input.MigrationDB.BackwardMigrate(name)
+		updateSystemStep, err := input.MigrationDB.BackwardMigrate(name)
 		if err != nil {
 			return nil, err
 		}
 
 		s := Steps{
 			backwardStep,
-			updateMetaStep,
+			updateSystemStep,
 		}
 		steps = append(steps, &StepTitleAndResult{
 			Step:  TransactionIfAllowed{s},
@@ -107,14 +107,14 @@ func Plan(input *PlanInput) (Steps, error) {
 			return nil, fmt.Errorf("error loading forward step for migration %q", name)
 		}
 
-		updateMetaStep, err := input.MigrationDB.ForwardMigrate(name)
+		updateSystemStep, err := input.MigrationDB.ForwardMigrate(name)
 		if err != nil {
 			return nil, err
 		}
 
 		s := Steps{
 			forwardStep,
-			updateMetaStep,
+			updateSystemStep,
 		}
 		steps = append(steps, &StepTitleAndResult{
 			Step:  TransactionIfAllowed{s},

--- a/step.go
+++ b/step.go
@@ -17,16 +17,16 @@ type ExecCtx struct {
 }
 
 type PrintCtx struct {
-	Output       Printer
-	PrintSQL     bool
-	PrintMetaSQL bool
+	Output         Printer
+	PrintSQL       bool
+	PrintSystemSQL bool
 }
 
 type SQLExecStep struct {
 	Query         string
 	Args          []interface{}
 	NoTransaction bool
-	IsMeta        bool
+	IsSystem      bool
 }
 
 func (o *SQLExecStep) Execute(ctx ExecCtx) error {
@@ -42,7 +42,7 @@ func (o *SQLExecStep) Print(ctx PrintCtx) {
 	if !ctx.PrintSQL || o.Query == "" {
 		return
 	}
-	if o.IsMeta && !ctx.PrintMetaSQL {
+	if o.IsSystem && !ctx.PrintSystemSQL {
 		return
 	}
 	ctx.Output.Println(strings.TrimSpace(o.Query))
@@ -117,7 +117,7 @@ func (o TransactionIfAllowed) Print(ctx PrintCtx) {
 		return
 	}
 
-	doPrint := ctx.PrintMetaSQL && o.AllowsTransaction()
+	doPrint := ctx.PrintSystemSQL && o.AllowsTransaction()
 	if doPrint {
 		ctx.Output.Println("BEGIN;")
 	}

--- a/step_test.go
+++ b/step_test.go
@@ -28,9 +28,9 @@ func TestSQLExecStep_Execute(t *testing.T) {
 		printer := NewMockPrinter(ctrl)
 
 		step := &SQLExecStep{
-			Query:  "fake query",
-			Args:   []interface{}{"str", 42},
-			IsMeta: false,
+			Query:    "fake query",
+			Args:     []interface{}{"str", 42},
+			IsSystem: false,
 		}
 		ctx := ExecCtx{
 			DB:     db,
@@ -48,9 +48,9 @@ func TestSQLExecStep_Execute(t *testing.T) {
 		printer := NewMockPrinter(ctrl)
 
 		step := &SQLExecStep{
-			Query:  "fake query",
-			Args:   []interface{}{"str", 42},
-			IsMeta: false,
+			Query:    "fake query",
+			Args:     []interface{}{"str", 42},
+			IsSystem: false,
 		}
 		ctx := ExecCtx{
 			DB:     db,
@@ -65,14 +65,14 @@ func TestSQLExecStep_Execute(t *testing.T) {
 }
 
 func TestSQLExecStep_Print(t *testing.T) {
-	t.Run("IsMeta=false PrintSQL=false", func(t *testing.T) {
+	t.Run("IsSystem=false PrintSQL=false", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		printer := NewMockPrinter(ctrl)
 
 		step := &SQLExecStep{
-			Query:  "fake query",
-			Args:   []interface{}{"str", 42},
-			IsMeta: false,
+			Query:    "fake query",
+			Args:     []interface{}{"str", 42},
+			IsSystem: false,
 		}
 		ctx := PrintCtx{
 			Output:   printer,
@@ -80,15 +80,15 @@ func TestSQLExecStep_Print(t *testing.T) {
 		}
 		step.Print(ctx)
 	})
-	t.Run("IsMeta=false PrintSQL=true", func(t *testing.T) {
+	t.Run("IsSystem=false PrintSQL=true", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		writer := NewMockWriter(ctrl)
 		printer := NewPrinter(writer)
 
 		step := &SQLExecStep{
-			Query:  "fake query",
-			Args:   []interface{}{"str", 42},
-			IsMeta: false,
+			Query:    "fake query",
+			Args:     []interface{}{"str", 42},
+			IsSystem: false,
 		}
 		ctx := PrintCtx{
 			Output:   printer,
@@ -99,34 +99,34 @@ func TestSQLExecStep_Print(t *testing.T) {
 
 		step.Print(ctx)
 	})
-	t.Run("IsMeta=true PrintMetaSQL=false", func(t *testing.T) {
+	t.Run("IsSystem=true PrintSystemSQL=false", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		printer := NewMockPrinter(ctrl)
 
 		step := &SQLExecStep{
-			Query:  "fake query",
-			Args:   []interface{}{"str", 42},
-			IsMeta: true,
+			Query:    "fake query",
+			Args:     []interface{}{"str", 42},
+			IsSystem: true,
 		}
 		ctx := PrintCtx{
-			Output:       printer,
-			PrintMetaSQL: false,
+			Output:         printer,
+			PrintSystemSQL: false,
 		}
 		step.Print(ctx)
 	})
-	t.Run("IsMeta=true PrintMetaSQL=true", func(t *testing.T) {
+	t.Run("IsSystem=true PrintSystemSQL=true", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		writer := NewMockWriter(ctrl)
 		printer := NewPrinter(writer)
 
 		step := &SQLExecStep{
-			Query:  "fake query",
-			Args:   []interface{}{"str", 42},
-			IsMeta: true,
+			Query:    "fake query",
+			Args:     []interface{}{"str", 42},
+			IsSystem: true,
 		}
 		ctx := PrintCtx{
-			Output:       printer,
-			PrintMetaSQL: true,
+			Output:         printer,
+			PrintSystemSQL: true,
 		}
 
 		writer.EXPECT().Write(gomock.Any()).MinTimes(1)


### PR DESCRIPTION
We differentiate two set of SQL statements:

1. SQL that is executed by the user: these are the statements in the migration .sql files.
2. SQL that is executed for the administration of the migrations. These SQL statements update the migrations table and open/commit transaction when it makes sense.

The second category was called 'meta' SQL but this change renames this to 'sys' SQL or 'system' SQL.