### PR TITLE
Add config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,103 +23,14 @@ Run `migrate -help` for commandline options.
 
 ### 1. Create a config file
 
-Create a `migrate.yml` config file somewhere in your project repo:
-
-```yaml
-dev:
-  db:
-    # DB driver: can be postgres or mysql
-    driver: postgres
-
-    # DB driver specific connection parameters.
-    # In case of mysql it looks like this: user@tcp(localhost:3306)/db_name
-    #
-    # Mysql data_source format: https://github.com/go-sql-driver/mysql#dsn-data-source-name
-    # Postgres data_source format: https://godoc.org/github.com/lib/pq
-    data_source: 'postgres://steve@localhost:5432/postgres?sslmode=disable'
-
-    # The name of the migrations table. Optional, default value: migrations
-    #migrations_table: migrations
-
-  migration_source:
-    # The relative or absolute path to the directory that contains the migration files.
-    # A relative path is relative to the parent dir of this config file.
-    path: migrations
-
-    # The filename pattern of the SQL migration files. It is a template string
-    # with a few placeholders. Each placeholder consists of a name and
-    # zero or more key:value pairs. E.g.: '[id]' or '[id,key1=val1,key2=val2]'
-    #
-    # You can use the following placeholders:
-    #
-    # [id,generate:<type>,width:<width>]
-    #
-    #       The numeric ID of the migration file. The parameters are used by the
-    #       `migrate new` command to generate and format a new ID.
-    #
-    #       The generate:<type> parameter can be generate:sequence or
-    #       generate:unix_time. Default: generate:sequence
-    #
-    #       The <width> parameter can be a number between 1 and 50. Default: 4
-    #       It controls the zero padding of the ID. Zero padding isn't needed
-    #       by the migrate tool but it looks better especially when your tools
-    #       list the migration files in alphabetical order.
-    #
-    #       The id placeholder is required.
-    #
-    # [direction,forward:<forward>,backward:<backward>]
-    #
-    #       The direction of the migration formatted into the filename.
-    #       This placeholder is optional. If you put it to the filename pattern
-    #       then your forward and backward migrations will be split into separate
-    #       files. Not using this placeholder means that the backward and
-    #       forward part of a migration go to a single file.
-    #
-    #       The forward:<forward> parameter defines what string to put into
-    #       the name of forward migration files. The backward:<backward> parameter
-    #       does the same for backward migration files.
-    #       Defaults: forward:forward backward:backward
-    #
-    # [description,space:<space>,prefix:<prefix>,suffix:<suffix>]
-    #
-    #       The description placeholder is optional. If you leave it out from
-    #       the filename pattern then you won't be able to add description into
-    #       the names of your migration files.
-    #
-    #       If you use the description placeholder without the prefix:<prefix>
-    #       and suffix:<suffix> parameters then the description in your migration
-    #       filenames will be required and has to be at least 1 character long.
-    #
-    #       If you specify at least one of the prefix or suffix parameters then
-    #       the description is optional in your filenames. The prefix and
-    #       suffix are glued to the description only when it is present.
-    #
-    #       The space:<space> parameter is used by the `migrate new` command
-    #       to replace space characters of the description to something more
-    #       filename friendly. E.g.: `migrate new "my first description"`
-    #       would put "my_first_description" into the filename with space:_
-    #
-    #       Defaults: space:_ prefix: suffix:
-    #
-    # If you want to escape a special character (one of the []: characters) then
-    # prefix it with a backtick (`). You can escape the backtick too.
-    #
-    # The filename_pattern setting is optional.
-    # Default: '[id][description,prefix:_].sql'
-    #filename_pattern: '[id][description,prefix:_].[direction,forward:fw,backward:bw].sql'
-
-prod:
-  db:
-    driver: postgres
-    data_source: 'postgres://service@localhost:5432/postgres'
-    #migrations_table: migrations
-  migration_source:
-    path: migrations
-    #filename_pattern: '[id][description,prefix:_].[direction,forward:fw,backward:bw].sql'
+```bash
+migrate config > migrate.yml
 ```
 
-The above config defines two database settings: `dev` and `prod`.
-You can use any number of settings with user defined names.
+Edit the config by following the instructions in it.
+
+The template config defines two database settings - `dev` and `prod` - but
+you can use any number of settings with user defined names.
 Use the `-db <name>` option of the `migrate` command to select one of these settings.
 If you don't use the `-db <name>` option then the default is `dev`.
 
@@ -149,7 +60,8 @@ migrate new "initial migration"
 ```
 
 The above command creates a `<migrations_dir>/0001_initial_migration.sql` file.
-Edit it with an editor. In my example I create two simple tables:
+The filename will be different if you specified a filename_pattern in the config.
+Edit the migration file. In my example I create two simple tables:
 
 ```sql
 -- +migrate forward


### PR DESCRIPTION
Adding the `migrate config` command that prints a config template to stdout which can be redirected into a config file.