### PR TITLE
Move allow_past_migrations to the right place

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -179,6 +179,28 @@ const configTemplate = `dev:
     # Optional. Default: '[id][description,prefix:_].sql'
     #filename_pattern: '[id][description,prefix:_].[direction,forward:fw,backward:bw].sql'
 
+  # If allow_migration_gaps==false (which is the default setting) then the plan
+  # and goto commands fail with an error message if there is at least one
+  # unapplied migration that is older (has smaller ID) than an applied migration.
+  #
+  # The easiest way to get into the previously described problematic situation
+  # is using unx_time as the migration ID that allows unused ID values between
+  # migrations. This can be problematic because switching between branches or
+  # merging someone else's work into your workspace might place an unapplied
+  # migration between two applied past migrations. Applying a past migration
+  # (a gap) like that is harmless if it touches the schema/data in a way that
+  # doesn't interfere/conflict with applied future migrations but you can never
+  # know when you handle the flattening of that dependency graph manually.
+  #
+  # Another way to open a gap (or close one) in the past is using the
+  # ` + "`" + `migrate hack` + "`" + ` command to unapply or apply migrations one-by-one.
+  #
+  # For the above reasons the default migration ID generation method uses a
+  # continuous sequence of integers starting from 1 and allow_migration_gaps=false.
+  #
+  # Optional. Default: false
+  #allow_migration_gaps: true
+
 prod:
   db:
     driver: postgres
@@ -406,6 +428,9 @@ const hackUsage = `Usage: migrate hack [-force] [-useronly|-sysonly] <forward|ba
 
 Forward- or backward-migrate a single step specified by <migration_id>.
 Useful for troubleshooting.
+
+Originally I wanted to call this command 'step' but decided to use 'hack' as a deterrent.
+If you have to use this command instead of goto then you are already in trouble.
 
 It executes two sets of SQL statements:
 

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type dbConfig struct {
 
 	MigrationSourceType   string
 	MigrationSourceParams map[string]string
+	AllowMigrationGaps    bool
 }
 
 func (o *dbConfig) Validate() error {
@@ -48,8 +49,9 @@ func loadConfigFile(filename string) (map[string]*dbConfig, error) {
 	}
 
 	type section struct {
-		DB              map[string]string `yaml:"db"`
-		MigrationSource map[string]string `yaml:"migration_source"`
+		DB                 map[string]string `yaml:"db"`
+		MigrationSource    map[string]string `yaml:"migration_source"`
+		AllowMigrationGaps bool              `yaml:"allow_migration_gaps"`
 	}
 	var cfg map[string]*section
 	err = yaml.UnmarshalStrict(b, &cfg)
@@ -82,6 +84,7 @@ func loadConfigFile(filename string) (map[string]*dbConfig, error) {
 			DataSource:            dsn,
 			MigrationSourceType:   mst,
 			MigrationSourceParams: s.MigrationSource,
+			AllowMigrationGaps:    s.AllowMigrationGaps,
 		}, nil
 	}
 

--- a/migration_source.go
+++ b/migration_source.go
@@ -13,7 +13,6 @@ type MigrationEntries interface {
 	Name(index int) string
 	Steps(index int) (forward, backward Step, err error)
 	IndexForName(name string) (index int, ok bool)
-	AllowsPastMigrations() bool
 	New(args []string) (name string, err error)
 }
 

--- a/source/dir/migration_entries.go
+++ b/source/dir/migration_entries.go
@@ -73,10 +73,6 @@ func (o *entries) IndexForName(name string) (index int, ok bool) {
 	return
 }
 
-func (o *entries) AllowsPastMigrations() bool {
-	return o.Source.AllowPastMigrations
-}
-
 const newUsageFmtStr = `Usage: migrate new [-squashed] %s
 
 Creates a new migration file in the migration directory specified

--- a/source/dir/migration_source.go
+++ b/source/dir/migration_source.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"unicode"
 )
@@ -47,15 +46,6 @@ func (sourceFactory) NewMigrationSource(baseDir string, params map[string]string
 		path = filepath.Join(baseDir, path)
 	}
 
-	allowPastMigrations := false
-	if s, ok := takeParam("allow_past_migrations"); ok {
-		b, err := strconv.ParseBool(s)
-		if err != nil {
-			return nil, fmt.Errorf("invalid allow_past_migrations value: %q", s)
-		}
-		allowPastMigrations = b
-	}
-
 	filenamePattern, ok := takeParam("filename_pattern")
 	if !ok {
 		filenamePattern = defaultFilenamePattern
@@ -70,16 +60,14 @@ func (sourceFactory) NewMigrationSource(baseDir string, params map[string]string
 	}
 
 	return &source{
-		MigrationsDir:       path,
-		FilenamePattern:     pfp,
-		AllowPastMigrations: allowPastMigrations,
+		MigrationsDir:   path,
+		FilenamePattern: pfp,
 	}, nil
 }
 
 type source struct {
-	MigrationsDir       string
-	FilenamePattern     *parsedFilenamePattern
-	AllowPastMigrations bool
+	MigrationsDir   string
+	FilenamePattern *parsedFilenamePattern
 }
 
 func (o *source) MigrationEntries() (migrate.MigrationEntries, error) {


### PR DESCRIPTION
- Renamed the `allow_past_migrations` config setting to `allow_migration_gaps`.
- Moved the `allow_migration_gaps` check from the planner to higher level logic and to a different place in the config (outside migration_source).